### PR TITLE
`v1.0.4-alpha5`: use `concurrency_group_id` + set `cancel-in-progress` to true for direct testing triggers

### DIFF
--- a/.github/workflows/publish-release-to-pypi.yml
+++ b/.github/workflows/publish-release-to-pypi.yml
@@ -62,6 +62,8 @@ jobs:
     # and substitute with the actual value, like macros work in C:
     # if: ${{ github.repository_owner == 'Lex-DRL' }}
     uses: ./.github/workflows/test.yml
+    with:
+      concurrency_group_id: 'publish'
 
   # --------------------------------------------------------
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ permissions:
 
 concurrency:
   group: test-${{ inputs.concurrency_group_id }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.sha }}
-  cancel-in-progress: ${{ inputs.concurrency_group_id != 'direct-trigger' }}
+  cancel-in-progress: ${{ inputs.concurrency_group_id == '' }}
 
 jobs:
   test:
@@ -76,7 +76,7 @@ jobs:
         run: |
           echo "Concurrency group: test-${{ inputs.concurrency_group_id }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.sha }}"
           echo "Concurrency group-ID: ${{ inputs.concurrency_group_id }}"
-          echo "Cancel in progress: ${{ inputs.concurrency_group_id != 'direct-trigger' }}"
+          echo "Cancel in progress: ${{ inputs.concurrency_group_id == '' }}"
           echo "Event name: ${{ github.event_name }}"
           echo "SHA: ${{ github.sha }}"
           echo "PR number: ${{ github.event.pull_request.number }}"

--- a/src/docstring_to_text/___package_meta.py
+++ b/src/docstring_to_text/___package_meta.py
@@ -6,7 +6,13 @@
 
 # It should be a hard-coded string, as close to the beginning of file as possible,
 # for Hatchling build tools to properly parse it:
-VERSION = "1.0.4-alpha4"
+VERSION = "1.0.4-alpha5"
+# For suffixed versions here ^, the full name should be used, separated with dash:
+# '-alpha1'
+# '-beta1'
+# '-rc1'  # kinda "full"
+# By the build tools, they'll still be turned into -a1, -b1, etc.
+# But at least release names on GitHub will be nice.
 
 
 # =============================================================


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Improved release pipeline concurrency to prevent overlapping workflow runs and refined cancellation behavior for in-progress runs.
  - Updated debug messaging in CI to reflect new concurrency conditions.
  - Bumped package version to 1.0.4-alpha5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->