### PR TITLE
`concurrency_group_id` for `version-parse.yml`, too

### DIFF
--- a/.github/workflows/publish-release-to-pypi.yml
+++ b/.github/workflows/publish-release-to-pypi.yml
@@ -71,6 +71,8 @@ jobs:
     name: Version 🔢
     needs: test
     uses: ./.github/workflows/version-parse.yml
+    with:
+      concurrency_group_id: 'publish'
 
   # --------------------------------------------------------
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ on:
           + to let callers define their own groups.
         required: false
         type: string
-        default: 'called'  # For other trigger events, should be empty
+        default: 'called'  # Empty for other trigger events (in this workflow)
 
   workflow_dispatch:  # ... or "launchable" manually
 

--- a/.github/workflows/version-parse.yml
+++ b/.github/workflows/version-parse.yml
@@ -6,6 +6,15 @@ name: Parse version 🔢
 
 on:
   workflow_call:  # Callable from other workflows
+    inputs:
+      concurrency_group_id:
+        description: >-
+          Should be set to some non-empty string - to differentiate from direct test-workflow triggers
+          + to let callers define their own groups.
+        required: false
+        type: string
+        default: 'called'  # Empty for other trigger events (in this workflow)
+
     outputs:  # Pass the detected outputs to the calling workflow
       tag_name:
         description: "The full tag name: v1.0.0-alpha1"
@@ -26,8 +35,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: version_parse-${{ github.event_name }}-${{ github.event.pull_request.number || github.sha }}
-  cancel-in-progress: ${{ github.event_name != 'workflow_call' }}
+  group: version_parse-${{ inputs.concurrency_group_id }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ inputs.concurrency_group_id == '' }}
 
 env:
   VERSION_FILE: 'src/docstring_to_text/___package_meta.py'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved concurrency handling in CI workflows to group related runs and minimize duplicate executions during testing, version parsing, and release publishing.
* **Documentation**
  * Clarified inline comments in the test workflow to better explain concurrency behavior for different trigger events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->